### PR TITLE
chore: sync AGENTS.md rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ secrets/*
 .python-version
 generated
 specialpurpose/bobskeys.py
+.worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,9 @@ All agents must follow these rules:
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
 4) PR descriptions must include Summary, Rationale, and Details sections.
+5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
+6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
+7) Update dependency lockfiles when adding or removing Python dependencies.
+8) Keep base image tags pinned.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/
-
-## Condition: repo contains Python files
-Rules:
-- Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
-- Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
-- Update dependency lockfiles when adding or removing Python dependencies.
-
-## Condition: repo contains one or more Dockerfile
-Rules:
-- Keep base image tags pinned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Requirements
+
+All agents must follow these rules:
+
+1) Fully test your changes before submitting a PR (run the full suite or all relevant tests).
+2) PR titles must be descriptive and follow Conventional Commits-style prefixes:
+   - Common: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `perf:`
+   - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
+3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
+4) PR descriptions must include Summary, Rationale, and Details sections.
+
+Reference: https://www.conventionalcommits.org/en/v1.0.0/
+
+## Condition: repo contains Python files
+Rules:
+- Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
+- Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
+- Update dependency lockfiles when adding or removing Python dependencies.
+
+## Condition: repo contains one or more Dockerfile
+Rules:
+- Keep base image tags pinned.


### PR DESCRIPTION
Summary
- Sync AGENTS.md rules to include baseline requirements and applicable conditions.
- Ignore .worktrees in .gitignore.

Rationale
- Keep agent expectations consistent across repos.
- Support rule-syncer validation of required AGENTS rules.

Details
- Updated AGENTS.md for baseline + conditional rules.
- Updated .gitignore to include .worktrees where needed.