### PR TITLE
chore: update AGENTS guidance and ignore worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,6 @@ All agents must follow these rules:
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
 4) PR descriptions must include Summary, Rationale, and Details sections.
-5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
-6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
-7) Update dependency lockfiles when adding or removing Python dependencies.
-8) Keep provisioning YAML and dashboard JSON in sync (add/remove entries together).
-9) Preserve dashboard uid values to avoid breaking links.
-10) Prefer exporting dashboards in a stable JSON format to minimize diffs.
+5) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Add remote-branch update guidance in `AGENTS.md`.
- Ignore `.worktrees/` in `.gitignore`.

Rationale:
- Keeps worktree folders out of source control and ensures work starts from the latest remote state.

Details:
- Document the remote-branch update step in `AGENTS.md`.
- Add `.worktrees/` to `.gitignore`.